### PR TITLE
Don't run load/optimization tests on up

### DIFF
--- a/src/app_ux/backend/AssistantSkills.cs
+++ b/src/app_ux/backend/AssistantSkills.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using System.Text.Json;
-using Google.Protobuf;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Extensions.OpenAI.Assistants;
 using Microsoft.Extensions.Logging;
@@ -41,6 +40,9 @@ public class BaseballAgentClient
 /// </summary>
 public class AssistantSkills
 {
+    private readonly HttpClient httpClient;
+    private readonly BaseballAgentClient client;
+
     readonly ITodoManager todoManager;
     readonly ILogger<AssistantSkills> logger;
 
@@ -52,6 +54,9 @@ public class AssistantSkills
     /// </remarks>
     public AssistantSkills(ITodoManager todoManager, ILogger<AssistantSkills> logger)
     {
+
+        httpClient = new HttpClient();
+        client = new BaseballAgentClient(httpClient);
         this.todoManager = todoManager ?? throw new ArgumentNullException(nameof(todoManager));
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -68,11 +73,9 @@ public class AssistantSkills
             string question
     )
     {
-        var httpClient = new HttpClient();
-        var client = new BaseballAgentClient(httpClient);
-
+        logger.LogInformation("GetBaseBallStats: Asking baseball stats: {question}", question);
         var response = await client.PostQueryAsync(question);
-        this.logger.LogInformation("Baseball stats: {result}", response);
+        logger.LogInformation("GetBaseBallStats: Action result is: {result}", response);
 
         return response;
     }
@@ -89,7 +92,7 @@ public class AssistantSkills
             object inputIgnored
     )
     {
-        this.logger.LogInformation("Fetching list of todos");
+        this.logger.LogInformation("GetTodos: Fetching list of todos");
 
         return this.todoManager.GetTodosAsync();
     }

--- a/src/function_upload_data/scripts/postdeploy.ps1
+++ b/src/function_upload_data/scripts/postdeploy.ps1
@@ -364,25 +364,25 @@ Create-TestProfile -TestProfileDisplayName $TestProfileDisplayName -TestProfileD
 
 # Not Running Test Profile Run by default
 
-# Create Test Profile Run
-$TestProfileRunRequest = @{
-    "testProfileId" = $TestProfileId;
-    "displayName"   = $TestProfileRunDisplayName;
-}
+# # Create Test Profile Run
+# $TestProfileRunRequest = @{
+#     "testProfileId" = $TestProfileId;
+#     "displayName"   = $TestProfileRunDisplayName;
+# }
 
-$TestProfileRunId = (New-Guid).ToString().ToLower()
-Log "Creating TestProfileRun with ID: $TestProfileRunId"
-$TestProfileRunURL = "$DataPlaneURL/test-profile-runs/$TestProfileRunId`?api-version=$ApiVersion"
+# $TestProfileRunId = (New-Guid).ToString().ToLower()
+# Log "Creating TestProfileRun with ID: $TestProfileRunId"
+# $TestProfileRunURL = "$DataPlaneURL/test-profile-runs/$TestProfileRunId`?api-version=$ApiVersion"
 
-try {
-    $TestProfileRunResp = Call-AzureLoadTesting -URL $TestProfileRunURL -Method 'PATCH' -Body $TestProfileRunRequest
-    Write-Host -ForegroundColor Green "Successfully created the test profile run"
-}
-catch {
-    Write-Host -ForegroundColor Red "Error: Failed to create test profile run $TestProfileRunId"
-    Write-Host $_.Exception.Message 
-    exit 1
-}
+# try {
+#     $TestProfileRunResp = Call-AzureLoadTesting -URL $TestProfileRunURL -Method 'PATCH' -Body $TestProfileRunRequest
+#     Write-Host -ForegroundColor Green "Successfully created the test profile run"
+# }
+# catch {
+#     Write-Host -ForegroundColor Red "Error: Failed to create test profile run $TestProfileRunId"
+#     Write-Host $_.Exception.Message 
+#     exit 1
+# }
 
 # $EncodedFunctionResourceId = UrlEncodeWithCapitalHex -StringToEncode "$FunctionAppResourceId"
 # $EncodedAltResourceId = UrlEncodeWithCapitalHex -StringToEncode "$LoadTestResourceId"

--- a/src/function_upload_data/scripts/postdeploy.sh
+++ b/src/function_upload_data/scripts/postdeploy.sh
@@ -325,4 +325,4 @@ create_and_configure_load_test "$TestId" "$LoadTestResourceName" "$ResourceGroup
 create_test_profile "$TestProfileDisplayName" "$TestProfileDescription" "$TestId" "$FunctionAppResourceId" "$DataPlaneURL" "$TestProfileId" "$ApiVersion"
 
 # Create Test Profile Run
-create_test_profile_run "$TestProfileId" "$TestProfileRunDisplayName" "$DataPlaneURL" "$ApiVersion"
+# create_test_profile_run "$TestProfileId" "$TestProfileRunDisplayName" "$DataPlaneURL" "$ApiVersion"

--- a/src/function_upload_data/tests/loadtest.sh
+++ b/src/function_upload_data/tests/loadtest.sh
@@ -1,0 +1,1 @@
+plow https://func-uploaddata-a46w3iang23zy-functions.azurewebsites.net/api/upload_data_single -c 500 --body @testdata.csv -T 'text/csv' -m POST -d 5m

--- a/src/function_upload_data/tests/testdata.csv
+++ b/src/function_upload_data/tests/testdata.csv
@@ -1,0 +1,2 @@
+playerID,birthYear,birthMonth,birthDay,birthCountry,birthState,birthCity,deathYear,deathMonth,deathDay,deathCountry,deathState,deathCity,nameFirst,nameLast,nameGiven,weight,height,bats,throws,debut,finalGame,retroID,bbrefID
+aardsda01,1981,12,27,USA,CO,Denver,,,,,,,David,Aardsma,David Allan,220,75,R,R,2004-04-06,2015-08-23,aardd001,aardsda01


### PR DESCRIPTION
This is too expensive to do on every `azd up` for cost/time reasons.

It's simply commented out.